### PR TITLE
Feature/daily-boxes-get 모든 데일리박스 GET, 특정 데일리박스 GET API

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -63,12 +63,14 @@ exports.login = async (req, res, next) => {
     return res.status(200).json({ accessToken, refreshToken, result: 'ok' });
   } catch (error) {
     console.error(error);
+
     return next(new HttpError(500, ERRORS.PROCESS_ERR));
   }
 };
 
 exports.refresh = async (req, res, next) => {
   const { refreshToken } = req.body;
+
   if (!refreshToken) {
     return next(new HttpError(400, ERRORS.AUTH.NEED_REFRESH_TOKEN));
   }

--- a/controllers/calendarController.js
+++ b/controllers/calendarController.js
@@ -9,7 +9,7 @@ const TWO_DAYS_DIFFERENCE = 2;
 
 exports.getBaseInfo = async (req, res, next) => {
   const { userId } = req.user;
-  
+
   try {
     const calendar = await Calendar.findById(req.params.calendarId).lean();
 
@@ -154,5 +154,30 @@ exports.postDailyBoxes = async (req, res, next) => {
       return next(new HttpError(400, validationErrors));
     }
     return next(new HttpError(500, ERRORS.PROCESS_ERR));
+  }
+};
+
+exports.getAllBoxes = async (req, res, next) => {
+  const { userId } = req.user;
+
+  try {
+    const calendar = await Calendar.findById(req.params.calendarId).populate(
+      'dailyBoxes',
+    );
+
+    if (!calendar) {
+      return next(new HttpError(404, ERRORS.CALENDAR.NOT_FOUND));
+    }
+
+    if (calendar.userId.toString() !== userId) {
+      return next(new HttpError(403, ERRORS.AUTH.UNAUTHORIZED));
+    }
+
+    const dailyBoxes = calendar.dailyBoxes;
+
+    return res.status(200).json({ result: 'ok', dailyBoxes });
+  } catch (error) {
+    console.error(error);
+    return next(new HttpError(500, ERRORS.INTERNAL_SERVER_ERR));
   }
 };

--- a/controllers/calendarController.js
+++ b/controllers/calendarController.js
@@ -175,7 +175,38 @@ exports.getAllBoxes = async (req, res, next) => {
 
     const dailyBoxes = calendar.dailyBoxes;
 
+    if (!dailyBoxes) {
+      return next(new HttpError(404, ERRORS.CALENDAR.CONTENTS_NOT_FOUND));
+    }
+
     return res.status(200).json({ result: 'ok', dailyBoxes });
+  } catch (error) {
+    console.error(error);
+    return next(new HttpError(500, ERRORS.INTERNAL_SERVER_ERR));
+  }
+};
+
+exports.getDailyBoxes = async (req, res, next) => {
+  const { userId } = req.user;
+
+  try {
+    const calendar = await Calendar.findById(req.params.calendarId).lean();
+
+    if (!calendar) {
+      return next(new HttpError(404, ERRORS.CALENDAR.NOT_FOUND));
+    }
+
+    if (calendar.userId.toString() !== userId) {
+      return next(new HttpError(403, ERRORS.AUTH.UNAUTHORIZED));
+    }
+
+    const dailyBox = await DailyBox.findById(req.query.dailyBoxId).lean();
+
+    if (!dailyBox) {
+      return next(new HttpError(404, ERRORS.CALENDAR.CONTENTS_NOT_FOUND));
+    }
+
+    return res.status(200).json({ result: 'ok', dailyBox });
   } catch (error) {
     console.error(error);
     return next(new HttpError(500, ERRORS.INTERNAL_SERVER_ERR));

--- a/errorMessages.js
+++ b/errorMessages.js
@@ -26,6 +26,7 @@ module.exports = {
     DELETE_SUCCESS: '캘린더가 정상적으로 삭제되었습니다.',
     INVALID_OPTION: '해당 항목을 찾을 수 없습니다.',
     NOT_FOUND: '캘린더 정보를 찾을 수 없습니다.',
+    CONTENTS_NOT_FOUND: '입력한 컨텐츠 정보를 찾을 수 없습니다.',
     REQUIRED_OPTION: '반드시 하나의 옵션을 선택해주세요',
   },
 };

--- a/routes/calendarRoutes.js
+++ b/routes/calendarRoutes.js
@@ -4,17 +4,17 @@ const {
   postBaseInfo,
   putBaseInfo,
   postDailyBoxes,
+  getAllBoxes,
 } = require('../controllers/calendarController');
 const { verifyToken } = require('../middlewares/auth');
 
 const router = express.Router();
 
-router.get('/:calendarId/base-info', verifyToken, getBaseInfo);
-
 router.post('/', verifyToken, postBaseInfo);
-
+router.get('/:calendarId/base-info', verifyToken, getBaseInfo);
 router.put('/:calendarId/base-info', verifyToken, putBaseInfo);
 
 router.post('/:calendarId/daily-boxes', verifyToken, postDailyBoxes);
+router.get('/:calendarId/daily-boxes', verifyToken, getAllBoxes);
 
 module.exports = router;

--- a/routes/calendarRoutes.js
+++ b/routes/calendarRoutes.js
@@ -4,6 +4,7 @@ const {
   postBaseInfo,
   putBaseInfo,
   postDailyBoxes,
+  getDailyBoxes,
   getAllBoxes,
 } = require('../controllers/calendarController');
 const { verifyToken } = require('../middlewares/auth');
@@ -16,5 +17,6 @@ router.put('/:calendarId/base-info', verifyToken, putBaseInfo);
 
 router.post('/:calendarId/daily-boxes', verifyToken, postDailyBoxes);
 router.get('/:calendarId/daily-boxes', verifyToken, getAllBoxes);
+router.get('/:calendarId/daily-boxes/:dailyBoxId', verifyToken, getDailyBoxes);
 
 module.exports = router;


### PR DESCRIPTION
## PR 목적

daily-box GET API 추가

## 작업 내용

전체 데일리박스 가져오는 GET API 추가
각 데일리 박스 가져오는 GET API 추가

## 주의 사항

처음에 API 짤 때 특정 데일리박스만 가져오는 API를 생각했는데
API 작업 하면서 생각해보니 이미 만들어놓은 캘린더가 있는 유저의 경우
맨 처음에 모든 정보를 불러오는 API도 필요할 것 같아서 추가로 만들었습니다.
`/calendars/:calendarId/daily-boxes` -> 새로 추가한 전체 데일리박스 가져오는 API

<img width="1215" alt="image" src="https://github.com/DJmongkey/wonder-box-back/assets/120701125/7fa1a549-83f6-4746-8219-5d2a90497a0a">

`/calendars/:calendarId/daily-boxes/:dailyBoxId` -> 기존에 생각했던 각 데일리 박스 가져오는 API

<img width="1215" alt="image" src="https://github.com/DJmongkey/wonder-box-back/assets/120701125/27b42c8d-b595-4645-937d-51877c4ba950">

프론트에서 동일한 라우터를 사용하여 `/custom/daily-boxes/:calendarId` 모달창을 이용해 페이지 전환없이 각 컨텐츠를 보여주기 때문에 `:dailyBoxId`를 params로 보내주지 못해서
우선 각 컨텐츠 박스 클릭시 전체 조회해놓았던 이미 가지고 있는 데이터를 이용해서 모달 창에 컨텐츠 표시를 하고,
새로 내용을 불러 와야 할 경우 쿼리파라미터로 dailyBoxId를 보내서 처리하도록 백엔드에서 구현해놓았습니다.

혹시 몰라서 Notion `데일리박스 - GET` 칸반 부분에 내용 기록해놓았습니다

작업하다 추가 API 필요하거나 변경 요청사항 있을시 얘기해주세요~ 바로 수정하겠습니다!😉