### PR TITLE
feature/base-info-post 초기 데이터 저장 방식 수정

### DIFF
--- a/controllers/calendarController.js
+++ b/controllers/calendarController.js
@@ -63,6 +63,28 @@ exports.postBaseInfo = async (req, res, next) => {
       return next(new HttpError(400, ERRORS.CALENDAR.NOT_FOUND));
     }
 
+    const dailyBoxes = [];
+    const currentDate = new Date(startDate);
+    const lastDate = new Date(endDate);
+
+    while (currentDate <= lastDate) {
+      const dailyBox = await DailyBox.create({
+        date: currentDate,
+        content: {},
+        isOpen: true,
+      });
+
+      if (dailyBox) {
+        dailyBoxes.push(dailyBox._id);
+      }
+
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    calendar.dailyBoxes = dailyBoxes;
+
+    await calendar.save();
+
     await User.updateOne(
       { _id: userId },
       { $addToSet: { calendars: calendar._id } },


### PR DESCRIPTION
## PR 목적

초기 데이터 저장 방식 수정

## 작업 내용

처음 캘린더 생성시 base-info에서 post할 때
dailybox도 DB에 같이 생성되게 하여 date에는 날짜, content에는 빈값으로 들어가는 방식으로 수정
이렇게 하여 DailyBoxes 페이지에서 기간만큼 박스 생성시 바로 사용할 수 있도록 함

## 주의 사항

